### PR TITLE
finish_for at JobBuffer place

### DIFF
--- a/caravan/Administrator.x10
+++ b/caravan/Administrator.x10
@@ -55,9 +55,9 @@ public class Administrator {
 
     val jobExecutionBegin = timer.milliTime();
 
-    for( i in 0..(numBuffers-1) ) {
+    finish for( i in 0..(numBuffers-1) ) {
       val bufPlace = (i==0) ? 1 : i*numProcPerBuf;
-      at( Place(bufPlace) ) @Uncounted async {
+      at( Place(bufPlace) ) async {
         val minConsPlace = here.id+1;
         val maxConsPlace = Math.min( (i+1)*numProcPerBuf, Place.numPlaces() ) - 1;
         if( i==0 ) { logger.d("JobBuffer is being initialized"); }
@@ -77,9 +77,6 @@ public class Administrator {
       }
     }
 
-    at( refJobProducer ) {
-      refJobProducer().waitCompletion();
-    }
     val terminationBegin = timer.milliTime();
 
     at( refJobProducer ) {

--- a/caravan/JobBuffer.x10
+++ b/caravan/JobBuffer.x10
@@ -126,7 +126,7 @@ class JobBuffer {
     val refProd = m_refProducer;
     val bufPlace = here;
     async {
-      at( refProd ) @Uncounted async {
+      at( refProd ) async {
         refProd().saveResults( results, bufPlace );
       }
       m_isSendingResults.set(false);  // Producer is ready to receive other results
@@ -180,17 +180,19 @@ class JobBuffer {
       consumerPlaces = m_freePlaces.clone();
       m_freePlaces.clear();
     }
-    for( pair in consumerPlaces ) {
+    async {
+    finish for( pair in consumerPlaces ) {
       val place = pair.first;
       val timeOut = pair.second;
       d("Buffer launching consumers at " + place);
-      at( place ) @Uncounted async {
+      at( place ) async {
         val consumer = new JobConsumer( refMe, m_logger.m_refTime );
         consumer.setExpiration( timeOut );
         consumer.run();
       }
+      d("Buffer launched all free consumers");
     }
-    d("Buffer launched all free consumers");
+  }
   }
 }
 

--- a/caravan/JobConsumer.x10
+++ b/caravan/JobConsumer.x10
@@ -58,7 +58,7 @@ class JobConsumer {
       if( hasEnoughResults() ) {
         val results = m_results.toRail();
         m_results.clear();
-        at( refBuf ) @Uncounted async {
+        at( refBuf ) async {
           refBuf().saveResults( results );
         }
       }


### PR DESCRIPTION
Bufferのplaceで`finish for`を実行するようにして、`@Uncounted`を使うのをやめる。これによりコードがスッキリするだけじゃなく、resumeやジョブの追加もこれまで通りにできるようになる。
